### PR TITLE
Reintroduce the server capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ COPY --from=builder /go/bin/draas /usr/bin/draas
 EXPOSE 8000
 
 ENTRYPOINT ["/usr/bin/draas"]
+CMD ["serve"]

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/travis-g/draas/dice"
+	"github.com/travis-g/draas/server"
 )
 
 func toJson(i interface{}) (string, error) {
@@ -17,6 +18,11 @@ func toJson(i interface{}) (string, error) {
 }
 
 func main() {
+	if os.Args[1] == "serve" {
+		exit, _ := server.Run()
+		os.Exit(exit)
+	}
+
 	roll, err := dice.Parse(os.Args[1])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/server/main.go
+++ b/server/main.go
@@ -28,7 +28,7 @@ var (
 	ValidCalcRegex = regexp.MustCompile(`(?i)^((\d+)|(\d*d\d+))((\s*[\+-]\s*)((\d+)|(\d*d\d+)))*$`)
 )
 
-func main() {
+func Run() (int, error) {
 	// Flag parsing
 	flag.BoolVar(&DebugMode, "debug", false, "run the server in debug mode with higher verbosity")
 	flag.BoolVar(&PrettifyLogs, "pretty", false, "prettify output logs. If false, outputs JSON logs")
@@ -88,5 +88,13 @@ func main() {
 	defer cancel()
 	srv.Shutdown(ctx)
 	log.Info().Msg("shutting down")
-	os.Exit(0)
+	return 0, nil
+}
+
+func main() {
+	exit, err := Run()
+	if err != nil {
+		log.Error().Err(err).Msg("exited with error")
+	}
+	os.Exit(exit)
 }


### PR DESCRIPTION
- Re-enables the server using the `server` subcommand 
- Changes the Dockerfile to run the server command by default

Notes:

- Flag parsing for the server is broken.